### PR TITLE
Fixes spelling for NIB_CRYPT_BUCKET_NAME

### DIFF
--- a/lib/nib/crypt/key.rb
+++ b/lib/nib/crypt/key.rb
@@ -28,13 +28,13 @@ module Nib
       end
 
       def bucket
-        ENV.fetch('NIB_CRYPT_BUCKENT_NAME') { raise MissingBucketError }
+        ENV.fetch('NIB_CRYPT_BUCKET_NAME') { raise MissingBucketError }
       end
 
       class MissingBucketError < StandardError
         def message
           <<-ERROR.tr("\n", '').gsub(/\s+/, ' ')
-            Please provide a bucket via the `NIB_CRYPT_BUCKENT_NAME`
+            Please provide a bucket via the `NIB_CRYPT_BUCKET_NAME`
             environment variable
           ERROR
         end


### PR DESCRIPTION
This changes the spelling to match the `README`.